### PR TITLE
Fix color change issue during output redirection

### DIFF
--- a/ct_win.go
+++ b/ct_win.go
@@ -105,12 +105,19 @@ func init() {
 }
 
 func resetColor() {
+	if initScreenInfo == nil { // No console info - Ex: stdout redirection
+		return
+	}
 	setConsoleTextAttribute(hStdout, initScreenInfo.WAttributes)
 }
 
 func changeColor(fg Color, fgBright bool, bg Color, bgBright bool) {
 	attr := uint16(0)
 	if fg == None || bg == None {
+		cbufinfo := getConsoleScreenBufferInfo(hStdout)
+		if cbufinfo == nil { // No console info - Ex: stdout redirection
+			return
+		}
 		attr = getConsoleScreenBufferInfo(hStdout).WAttributes
 	} // if
 


### PR DESCRIPTION
When command output is redirected to a file, console info is not available to set the colors resulting in a crash.
This is fixed with this change.
